### PR TITLE
Make it much faster

### DIFF
--- a/gpglib/content_parsers/base.py
+++ b/gpglib/content_parsers/base.py
@@ -59,7 +59,7 @@ class Parser(object):
             # Initialize the message, which is at a minimum:
             #   some nulls || salt || passphrase
             # Fill the rest of the message (up to `count`) with the string `salt + passphrase`
-            repeat_count = math.ceil((count - i) / len(combined))
+            repeat_count = int(math.ceil((count - i) / float(len(combined))))
             message = (b'\x00' * i) + (salt + passphrase) * repeat_count
 
             # Now hash the message

--- a/gpglib/content_parsers/base.py
+++ b/gpglib/content_parsers/base.py
@@ -1,7 +1,7 @@
 import math
 
 from gpglib.content_parsers.crypt import Mapped
-from gpglib.utils import binary_type, PY3
+from gpglib.utils import binary_type
 
 import itertools
 
@@ -46,12 +46,8 @@ class Parser(object):
         # The 'count' is the length of the data that gets hashed
         count = (16 + (raw_count & 15)) << ((raw_count >> 4) + 6)
 
-        # Initialize an infinite stream of salts + passphrases
+        # Combine the salt and passphrase for the repeating pattern
         combined = salt + passphrase
-        if PY3:
-            combined = [combined[i:i + 1] for i in range(len(combined))]
-        else:
-            combined = list(salt + passphrase)
 
         # Infinite for loop
         result = []
@@ -60,7 +56,7 @@ class Parser(object):
             #   some nulls || salt || passphrase
             # Fill the rest of the message (up to `count`) with the string `salt + passphrase`
             repeat_count = int(math.ceil((count - i) / float(len(combined))))
-            message = (b'\x00' * i) + (salt + passphrase) * repeat_count
+            message = (b'\x00' * i) + combined * repeat_count
 
             # Now hash the message
             hsh = hasher.new(message[:count]).digest()


### PR DESCRIPTION
Use a `data * repeat_count` to allocate memory once, at a slightly larger size than needed, then use an array slice to trim it down.

With my GPG private key, it used to take 3.5 seconds to parse the key, and over 1.3GB of ram.
Now it parses in 200ms and with a few hundred MB.

I also optimised the length check to not allocate more byte objects.